### PR TITLE
Add AI overview site with pages by skill level

### DIFF
--- a/advanced.html
+++ b/advanced.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>上級者向け AI解説</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>上級者向け AI解説</h1>
+        <nav>
+            <a href="index.html">ホームへ戻る</a>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h2>最新の研究トピック</h2>
+            <p>生成AI(Generative AI)や強化学習(Reinforcement Learning)の応用が注目されており、モデルの効率化や公平性などの研究も盛んです。</p>
+        </section>
+        <section>
+            <h2>開発者向けリソース</h2>
+            <ul>
+                <li>機械学習フレームワーク: PyTorch、TensorFlow</li>
+                <li>MLOpsのツール: Kubeflow、MLflow</li>
+                <li>大規模モデルを扱うための分散学習やハードウェア最適化</li>
+            </ul>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 AI Overview</p>
+    </footer>
+</body>
+</html>

--- a/beginner.html
+++ b/beginner.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>初心者向け AI解説</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>初心者向け AI解説</h1>
+        <nav>
+            <a href="index.html">ホームへ戻る</a>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h2>AIとは?</h2>
+            <p>人工知能(AI)は、人間のような知的行動を実現するコンピュータ技術の総称です。画像認識や音声認識、言語処理など、さまざまな分野で利用されています。</p>
+        </section>
+        <section>
+            <h2>現在よく使われている例</h2>
+            <ul>
+                <li>スマートフォンの音声アシスタント</li>
+                <li>Webサイトのおすすめ表示</li>
+                <li>自動翻訳サービス</li>
+            </ul>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 AI Overview</p>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AIの現状</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>AIの現状</h1>
+        <nav>
+            <ul>
+                <li><a href="beginner.html">初心者向け</a></li>
+                <li><a href="intermediate.html">中級者向け</a></li>
+                <li><a href="advanced.html">上級者向け</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main>
+        <p>このサイトでは、AIの現状についてレベル別に解説しています。興味のあるレベルを選択してください。</p>
+    </main>
+    <footer>
+        <p>&copy; 2024 AI Overview</p>
+    </footer>
+</body>
+</html>

--- a/intermediate.html
+++ b/intermediate.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>中級者向け AI解説</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>中級者向け AI解説</h1>
+        <nav>
+            <a href="index.html">ホームへ戻る</a>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h2>機械学習と深層学習</h2>
+            <p>機械学習はデータからパターンを学習する技術で、深層学習はその一種です。ニューラルネットワークを多層化することで、画像や音声などの複雑なデータから特徴を抽出できます。</p>
+        </section>
+        <section>
+            <h2>応用分野</h2>
+            <ul>
+                <li>画像認識による医療診断支援</li>
+                <li>自然言語処理によるチャットボット</li>
+                <li>ビッグデータ解析による需要予測</li>
+            </ul>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 AI Overview</p>
+    </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,33 @@
+body {
+    font-family: Arial, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+}
+header {
+    background-color: #333;
+    color: #fff;
+    padding: 1rem;
+}
+nav ul {
+    list-style: none;
+    padding: 0;
+}
+nav ul li {
+    display: inline;
+    margin-right: 1rem;
+}
+nav a {
+    color: #fff;
+    text-decoration: none;
+}
+main {
+    padding: 1rem;
+}
+footer {
+    text-align: center;
+    padding: 1rem;
+    background-color: #333;
+    color: #fff;
+}


### PR DESCRIPTION
## Summary
- add `index.html` for navigation
- add beginner, intermediate and advanced explanation pages
- style pages with `style.css`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d8a0d1238832f9fe53afd8cdc9116